### PR TITLE
Adding . to RamlWrap import to fix the path import issue.

### DIFF
--- a/ramlwrap/__init__.py
+++ b/ramlwrap/__init__.py
@@ -1,1 +1,1 @@
-from RamlWrap import ramlwrap
+from .RamlWrap import ramlwrap


### PR DESCRIPTION
Import issue is now fixed, which now allows the pip install to work correctly.