### PR TITLE
Remove middleware that causes failures on django < 1.8

### DIFF
--- a/tests/RamlWrapTest/settings.py
+++ b/tests/RamlWrapTest/settings.py
@@ -40,7 +40,6 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE_CLASSES = [
-    'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',


### PR DESCRIPTION
Fix your failing tests (probably)