### PR TITLE
API examples

### DIFF
--- a/ramlwrap/utils/raml.py
+++ b/ramlwrap/utils/raml.py
@@ -129,6 +129,12 @@ def _parse_child(resource, patterns, to_look_at, function_map, defaults):
                                     if two_hundred['body'][a.resp_content_type]:
                                         if "example" in two_hundred['body'][a.resp_content_type]:
                                             a.example = two_hundred['body'][a.resp_content_type]['example']
+                                        elif "examples" in two_hundred['body'][a.resp_content_type] and \
+                                                two_hundred['body'][a.resp_content_type]['examples']:
+                                            # If multiple examples in raml, just return the first one
+                                            examples = two_hundred['body'][a.resp_content_type]['examples'].values()
+                                            value_iterator = iter(examples)
+                                            a.example = next(value_iterator)
                                         
                 if "queryParameters" in act and act["queryParameters"]:
                     # FIXME: does this help in the query parameterising?

--- a/ramlwrap/views.py
+++ b/ramlwrap/views.py
@@ -115,9 +115,12 @@ class Method():
     request_content_type  = None
     request_schema        = None
     request_example       = None
+    request_examples      = None
+
     response_content_type = None
-    response_example      = None
     response_schema       = None
+    response_example      = None
+    response_examples     = None
     response_description  = None
 
 
@@ -197,6 +200,10 @@ def _parse_child(resource, endpoints, item_queue, rootnode=False):
                 if "example" in method_data['body'][m.request_content_type]:
                     m.request_example = method_data['body'][m.request_content_type]['example']
 
+                # Request examples
+                if "examples" in method_data['body'][m.request_content_type]:
+                    m.request_examples = method_data['body'][m.request_content_type]['examples']
+
             # Response
             if 'responses' in method_data and method_data['responses']:
                 for status_code in method_data['responses']:
@@ -214,6 +221,8 @@ def _parse_child(resource, endpoints, item_queue, rootnode=False):
                                         m.response_schema = _parse_schema_definitions(copy.deepcopy(m.response_schema_original))
                                     if "example" in response['body'][m.response_content_type]:
                                         m.response_example = response['body'][m.response_content_type]['example']
+                                    if "examples" in response['body'][m.response_content_type]:
+                                        m.response_examples = response['body'][m.response_content_type]['examples']
 
 
 def _parse_schema_definitions(schema):

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
 
-    version='2.2.0',
+    version='2.3.0',
 
     description='Raml API mapping toolkit for Django',
     long_description=long_description,

--- a/tests/RamlWrapTest/templates/ramlwrap_default_main.html
+++ b/tests/RamlWrapTest/templates/ramlwrap_default_main.html
@@ -157,6 +157,17 @@
               </div>
             {% endif %}
 
+            {% if method.request_examples %}
+              {% for key in method.request_examples %}
+                <p><strong>{{key}} Request Example:</strong></p>
+                <div class="card mb-4">
+                  <div class="card-body bg-light">
+                    <code>{{method.request_examples|hash:key|json_dump}}</code>
+                  </div>
+                </div>
+              {% endfor %}
+            {% endif %}
+
              <!-- Method response schema -->
             {% if method.response_schema %}
               <p><strong>Response:</strong></p>
@@ -175,6 +186,18 @@
                 </div>
               </div>
             {% endif %}
+
+            {% if method.response_examples %}
+              {% for key in method.response_examples %}
+                <p><strong>{{key}} Response Example:</strong></p>
+                <div class="card mb-4">
+                  <div class="card-body bg-light">
+                    <code>{{method.response_examples|hash:key|json_dump}}</code>
+                  </div>
+                </div>
+              {% endfor %}
+            {% endif %}
+
           </div>
         {% endfor %}
 

--- a/tests/RamlWrapTest/tests/fixtures/raml/ramlv1_tests.raml
+++ b/tests/RamlWrapTest/tests/fixtures/raml/ramlv1_tests.raml
@@ -1,0 +1,24 @@
+#%RAML 1.0
+---
+title: Test RamlWrap 1.0 API
+description: A series of useful APIs that can be used to test RamlWrap functionality.
+version:  v0.1
+mediaType:  application/json
+baseUri: http://example.com
+
+protocols: [HTTP]
+
+/ramlv1-api:
+  displayName: API root
+  /multi-example:
+    displayName: Multiple examples in RAML
+    get:
+      responses:
+        200:
+          body:
+            application/json:
+              examples:
+                one:
+                  {"exampleData": "This is the first example response"}
+                two:
+                  {"exampleData2": "This is a second example"}

--- a/tests/RamlWrapTest/tests/fixtures/raml/test.raml
+++ b/tests/RamlWrapTest/tests/fixtures/raml/test.raml
@@ -1,4 +1,4 @@
-#%RAML 0.8
+#%RAML 01.0
 ---
 title: Test RamlWrap API
 description: A series of useful APIs that can be used to test RamlWrap functionality.

--- a/tests/RamlWrapTest/tests/fixtures/raml/test.raml
+++ b/tests/RamlWrapTest/tests/fixtures/raml/test.raml
@@ -1,4 +1,4 @@
-#%RAML 01.0
+#%RAML 0.8
 ---
 title: Test RamlWrap API
 description: A series of useful APIs that can be used to test RamlWrap functionality.

--- a/tests/RamlWrapTest/tests/test_raml_v1.py
+++ b/tests/RamlWrapTest/tests/test_raml_v1.py
@@ -1,0 +1,54 @@
+"""Tests for RamlWrap"""
+import inspect
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../")))
+
+from ramlwrap.utils.raml import raml_url_patterns
+from django.test import TestCase, Client
+
+import django
+from distutils.version import StrictVersion
+
+
+def _get_parent_class(method):
+    """Return the class for the given method."""
+    members = inspect.getmembers(method)
+    for m in members:
+        if m[0] == "__self__":
+            return m[1]
+
+
+def _internal_mockfunc(request, example):
+    pass
+
+
+def _internal_mock_post(request, example):
+    """json loads the request and return it."""
+    return json.loads(request.validated_data)
+
+
+class RamlWrapv1TestCase(TestCase):
+    client = None
+
+    def setUp(self):
+        self.client = Client()
+
+    def test_raml_with_multiple_examples__only_one_is_returned(self):
+        """Test that a valid get request with no target returns
+        the example json.
+        """
+
+        expected_data_1 = {"exampleData": "This is the first example response"}
+        expected_data_2 = {"exampleData2": "This is a second example"}
+
+        response = self.client.get("/ramlv1-api/multi-example")
+        reply_data = response.content.decode("utf-8")
+        actual_response = json.loads(reply_data)
+
+        # Due to the unordered nature of dictionaries in certain Python versions, we are happy if either one of
+        # the examples is returned
+        self.assertTrue(actual_response == expected_data_1 or actual_response == expected_data_2)
+

--- a/tests/RamlWrapTest/urls.py
+++ b/tests/RamlWrapTest/urls.py
@@ -46,5 +46,5 @@ function_map = {
 # Load in test raml file
 urlpatterns.extend(ramlwrap("RamlWrapTest/tests/fixtures/raml/test.raml", function_map))
 urlpatterns.extend(ramlwrap("RamlWrapTest/tests/fixtures/raml/test_dynamic.raml", function_map))
-
+urlpatterns.extend(ramlwrap("RamlWrapTest/tests/fixtures/raml/ramlv1_tests.raml", function_map))
 


### PR DESCRIPTION
This will allow endpoints to have multiple named examples

**Example:**

```
responses:
    200:
        description: Card list and associated token requestors
        body:
          application/json:
            schema: !include json/get-available-cards-response.json
            examples:
              Apple Wallet:
                !include json/get-available-cards-response-apple-example.json
              Google Wallet:
                !include json/get-available-cards-response-google-example.json

```