### PR TITLE
Fixes RAML Docs to maintain RAML ordering of endpoints

### DIFF
--- a/ramlwrap/views.py
+++ b/ramlwrap/views.py
@@ -138,16 +138,21 @@ def _parse_child(resource, endpoints, item_queue, rootnode=False):
     else:
         level = resource['level']
 
+    # Storing endpoints in temporary array to preserve order
+    child_item_array = []
+
     # Parse children endpoints
     for key in node:
-
         if key.startswith("/"):
             item = {
                 "node"  : node[key],
                 "path"  : "%s%s" % (path, key),
                 "level" : level + 1
             }
-            item_queue.insert(0, item)
+            child_item_array.insert(0, item)
+
+    for i in child_item_array:
+        item_queue.insert(0, i)
 
     # Skip rootnode
     if rootnode:

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
 
-    version='2.3.0',
+    version='2.3.1',
 
     description='Raml API mapping toolkit for Django',
     long_description=long_description,

--- a/tests/RamlWrapTest/tests/fixtures/raml/test_multiple_responses.raml
+++ b/tests/RamlWrapTest/tests/fixtures/raml/test_multiple_responses.raml
@@ -1,0 +1,32 @@
+#%RAML 0.8
+---
+title: Test RamlWrap API
+description: A series of useful APIs that can be used to test RamlWrap functionality.
+version:  v0.1
+mediaType:  application/json
+baseUri: http://example.com
+
+protocols: [HTTP]
+
+/api:
+  displayName: API root
+  post:
+    body:
+      application/json:
+        schema: !include json/service_request.json
+        example: !include json/service_request_example.json
+    responses:
+        200:
+          description: A nice happy description
+          body:
+            application/json:
+              example: {"reason": "happyDays"}
+              schema: {"schema": "example"}
+        204:
+          description: No response body required
+        422:
+          body:
+            application/json:
+                example: {"reason": "invalidManatee"}
+        500:
+          description: A really unhappy server error.

--- a/tests/RamlWrapTest/tests/test_raml_api_docs.py
+++ b/tests/RamlWrapTest/tests/test_raml_api_docs.py
@@ -1,0 +1,51 @@
+"""Tests for RamlWrap"""
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../")))
+
+from ramlwrap.views import RamlDoc
+from django.test import TestCase, Client
+
+
+class RamlApiDocsTestCase(TestCase):
+
+    def test_responses(self):
+        """Test that the responses are returned as an array."""
+        doc = RamlDoc()
+        doc.raml_file = "RamlWrapTest/tests/fixtures/raml/test_multiple_responses.raml"
+        context = doc._parse_endpoints(None)
+
+        self.assertEqual(len(context["endpoints"][0].methods[0].responses), 4)
+
+        # Python tests before 3.6 cannot guarantee order of responses so search based on code
+        for response in context["endpoints"][0].methods[0].responses:
+            if response.status_code == 200:
+                self.assertEqual(response.description,
+                                 'A nice happy description')
+                self.assertEqual(response.content_type, 'application/json')
+                self.assertEqual(response.schema, {"schema": "example"})
+            elif response.status_code == 204:
+                self.assertEqual(response.status_code, 204)
+                self.assertEqual(response.description, 'No response body required')
+            elif response.status_code == 422:
+                self.assertEqual(response.status_code, 422)
+                self.assertIsNone(response.description)
+                self.assertEqual(len(response.examples), 1)
+                self.assertEqual(response.examples[0], {"reason": "invalidManatee"})
+            elif response.status_code == 500:
+                self.assertEqual(response.status_code, 500)
+                self.assertEqual(response.description, 'A really unhappy server error.')
+
+    def test_responses_backward_compatability(self):
+        """Test that 200 responses data is stored in legacy fields."""
+        doc = RamlDoc()
+        doc.raml_file = "RamlWrapTest/tests/fixtures/raml/test_multiple_responses.raml"
+        context = doc._parse_endpoints(None)
+
+        self.assertEqual(context["endpoints"][0].methods[0].response_content_type, 'application/json')
+        self.assertEqual(context["endpoints"][0].methods[0].response_description, 'A nice happy description')
+        self.assertEqual(context["endpoints"][0].methods[0].response_example, {"reason": "happyDays"})
+        self.assertIsNone(context["endpoints"][0].methods[0].response_examples)
+        self.assertEqual(context["endpoints"][0].methods[0].response_schema, {"schema": "example"})

--- a/tests/RamlWrapTest/tests/test_raml_v1.py
+++ b/tests/RamlWrapTest/tests/test_raml_v1.py
@@ -6,11 +6,8 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../")))
 
-from ramlwrap.utils.raml import raml_url_patterns
 from django.test import TestCase, Client
 
-import django
-from distutils.version import StrictVersion
 
 
 def _get_parent_class(method):


### PR DESCRIPTION
Fix to maintain order of child items whilst parsing endpoints
All response objects (based on status code in RAML) are stored in a new Responses object
Minor clean up of unused imports in unit test file