### PR TITLE
Bug in Responses array being statically defined

### DIFF
--- a/ramlwrap/views.py
+++ b/ramlwrap/views.py
@@ -125,10 +125,19 @@ class Method():
     response_examples     = None
     response_description  = None
 
-    responses = []
+    responses = None
+
+    def __init__(self):
+        self.responses = []
 
 
 class Response:
+    content_type = None
+    schema = None
+    schema_original = None
+    examples = None
+    description = None
+    status_code = None
 
     def __init__(self, content_type=None, schema=None, schema_original=None, description=None, status_code=None):
         self.content_type = content_type

--- a/tests/RamlWrapTest/tests/fixtures/raml/test_multiple_responses.raml
+++ b/tests/RamlWrapTest/tests/fixtures/raml/test_multiple_responses.raml
@@ -10,23 +10,35 @@ protocols: [HTTP]
 
 /api:
   displayName: API root
-  post:
-    body:
-      application/json:
-        schema: !include json/service_request.json
-        example: !include json/service_request_example.json
-    responses:
-        200:
-          description: A nice happy description
-          body:
-            application/json:
-              example: {"reason": "happyDays"}
-              schema: {"schema": "example"}
-        204:
-          description: No response body required
-        422:
-          body:
-            application/json:
-                example: {"reason": "invalidManatee"}
-        500:
-          description: A really unhappy server error.
+  /first:
+    displayName: First endpoint
+    post:
+      body:
+        application/json:
+          schema: !include json/service_request.json
+          example: !include json/service_request_example.json
+      responses:
+          200:
+            description: A nice happy description
+            body:
+              application/json:
+                example: {"reason": "happyDays"}
+                schema: {"schema": "example"}
+          204:
+            description: No response body required
+          422:
+            body:
+              application/json:
+                  example: {"reason": "invalidManatee"}
+          500:
+            description: A really unhappy server error.
+  /second:
+    displayName: Second endpoint
+    get:
+      body:
+        application/json:
+          schema: !include json/service_request.json
+          example: !include json/service_request_example.json
+      responses:
+          204:
+            description: No response body required

--- a/tests/RamlWrapTest/tests/test_raml_api_docs.py
+++ b/tests/RamlWrapTest/tests/test_raml_api_docs.py
@@ -11,16 +11,21 @@ from django.test import TestCase, Client
 
 class RamlApiDocsTestCase(TestCase):
 
-    def test_responses(self):
+    def test_first_endpoint_responses(self):
         """Test that the responses are returned as an array."""
         doc = RamlDoc()
         doc.raml_file = "RamlWrapTest/tests/fixtures/raml/test_multiple_responses.raml"
         context = doc._parse_endpoints(None)
 
-        self.assertEqual(len(context["endpoints"][0].methods[0].responses), 4)
+        # Find first endpoint (cannot guarantee order for Python 2.7 tests)
+        for endpoint in context["endpoints"]:
+            if endpoint.displayName == 'First endpoint':
+                first_endpoint_responses = endpoint.methods[0].responses
+
+        self.assertEqual(len(first_endpoint_responses), 4)
 
         # Python tests before 3.6 cannot guarantee order of responses so search based on code
-        for response in context["endpoints"][0].methods[0].responses:
+        for response in first_endpoint_responses:
             if response.status_code == 200:
                 self.assertEqual(response.description,
                                  'A nice happy description')
@@ -38,14 +43,34 @@ class RamlApiDocsTestCase(TestCase):
                 self.assertEqual(response.status_code, 500)
                 self.assertEqual(response.description, 'A really unhappy server error.')
 
-    def test_responses_backward_compatability(self):
-        """Test that 200 responses data is stored in legacy fields."""
+    def test_second_endpoint_responses(self):
+        """Test that the responses are returned as an array."""
         doc = RamlDoc()
         doc.raml_file = "RamlWrapTest/tests/fixtures/raml/test_multiple_responses.raml"
         context = doc._parse_endpoints(None)
 
-        self.assertEqual(context["endpoints"][0].methods[0].response_content_type, 'application/json')
-        self.assertEqual(context["endpoints"][0].methods[0].response_description, 'A nice happy description')
-        self.assertEqual(context["endpoints"][0].methods[0].response_example, {"reason": "happyDays"})
-        self.assertIsNone(context["endpoints"][0].methods[0].response_examples)
-        self.assertEqual(context["endpoints"][0].methods[0].response_schema, {"schema": "example"})
+        # Find first endpoint (cannot guarantee order for Python 2.7 tests)
+        for endpoint in context["endpoints"]:
+            if endpoint.displayName == 'Second endpoint':
+                second_endpoint_responses = endpoint.methods[0].responses
+
+        self.assertEqual(len(second_endpoint_responses), 1)
+        self.assertEqual(second_endpoint_responses[0].status_code, 204)
+        self.assertEqual(second_endpoint_responses[0].description, 'No response body required')
+
+    def test_responses_backward_compatability(self):
+        """Test that 200 responses data is stored in legacy fields for first endpoint."""
+        doc = RamlDoc()
+        doc.raml_file = "RamlWrapTest/tests/fixtures/raml/test_multiple_responses.raml"
+        context = doc._parse_endpoints(None)
+
+        # Find first endpoint (cannot guarantee order for Python 2.7 tests)
+        for endpoint in context["endpoints"]:
+            if endpoint.displayName == 'First endpoint':
+                first_endpoint_methods = endpoint.methods[0]
+
+        self.assertEqual(first_endpoint_methods.response_content_type, 'application/json')
+        self.assertEqual(first_endpoint_methods.response_description, 'A nice happy description')
+        self.assertEqual(first_endpoint_methods.response_example, {"reason": "happyDays"})
+        self.assertIsNone(first_endpoint_methods.response_examples)
+        self.assertEqual(first_endpoint_methods.response_schema, {"schema": "example"})


### PR DESCRIPTION
Responses array should not be statically defined. Added to init and more unit tests to check it has been fixed.