### PR TITLE
Static responses array bug

### DIFF
--- a/ramlwrap/views.py
+++ b/ramlwrap/views.py
@@ -125,10 +125,19 @@ class Method():
     response_examples     = None
     response_description  = None
 
-    responses = []
+    responses = None
+
+    def __init__(self):
+        self.responses = []
 
 
 class Response:
+    content_type = None
+    schema = None
+    schema_original = None
+    examples = None
+    description = None
+    status_code = None
 
     def __init__(self, content_type=None, schema=None, schema_original=None, description=None, status_code=None):
         self.content_type = content_type

--- a/ramlwrap/views.py
+++ b/ramlwrap/views.py
@@ -126,9 +126,11 @@ class Method():
     response_description  = None
 
     responses = None
+    examples = None
 
     def __init__(self):
         self.responses = []
+        self.examples = []
 
 
 class Response:
@@ -146,6 +148,15 @@ class Response:
         self.examples = []
         self.description = description
         self.status_code = status_code
+
+
+class Example:
+    title = None
+    body = None
+
+    def __init__(self, title=None, body=None):
+        self.title = title
+        self.body = body
 
 
 def _parse_child(resource, endpoints, item_queue, rootnode=False):
@@ -228,10 +239,15 @@ def _parse_child(resource, endpoints, item_queue, rootnode=False):
                 # Request example
                 if "example" in method_data['body'][m.request_content_type]:
                     m.request_example = method_data['body'][m.request_content_type]['example']
+                    m.examples.append(Example(body=method_data['body'][m.request_content_type]['example']))
 
                 # Request examples
                 if "examples" in method_data['body'][m.request_content_type]:
                     m.request_examples = method_data['body'][m.request_content_type]['examples']
+                    # New examples object
+                    for example in method_data['body'][m.request_content_type]['examples']:
+                        m.examples.append(
+                            Example(title=example, body=method_data['body'][m.request_content_type]['examples'][example]))
 
             # Response
             if 'responses' in method_data and method_data['responses']:
@@ -256,9 +272,17 @@ def _parse_response(m, method_data, status_code):
                     response_obj.schema = _parse_schema_definitions(
                         copy.deepcopy(response_obj.schema_original))
                 if "example" in response['body'][response_obj.content_type]:
-                    response_obj.examples.append(response['body'][response_obj.content_type]['example'])
+                    response_obj.examples.append(Example(body=response['body'][response_obj.content_type]['example']))
+                    # For backward compatability
+                    if status_code == 200:
+                        m.response_example = response['body'][response_obj.content_type]['example']
                 if "examples" in response['body'][response_obj.content_type]:
-                    response_obj.examples.extend(response['body'][response_obj.content_type]['examples'])
+                    for example in response['body'][response_obj.content_type]['examples']:
+                        response_obj.examples.append(
+                            Example(title=example, body=response['body'][response_obj.content_type]['examples'][example]))
+                    # For backward compatability
+                    if status_code == 200:
+                        m.response_example = response['body'][response_obj.content_type]['examples']
 
     # For backward compatability, store 200 responses in specific fields
     if status_code == 200:
@@ -266,10 +290,6 @@ def _parse_response(m, method_data, status_code):
         m.response_description = response_obj.description
         m.response_schema_original = response_obj.schema_original
         m.response_schema = response_obj.schema
-        if len(response_obj.examples) == 1:
-            m.response_example = response_obj.examples[0]
-        elif len(response_obj.examples) > 1:
-            m.response_example = response_obj.examples
 
     m.responses.append(response_obj)
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
 
-    version='2.3.1',
+    version='2.3.2',
 
     description='Raml API mapping toolkit for Django',
     long_description=long_description,

--- a/tests/RamlWrapTest/tests/fixtures/raml/test_multiple_examples.raml
+++ b/tests/RamlWrapTest/tests/fixtures/raml/test_multiple_examples.raml
@@ -1,0 +1,41 @@
+#%RAML 1.0
+---
+title: Test RamlWrap API
+description: A series of useful APIs that can be used to test RamlWrap functionality.
+version:  v0.1
+mediaType:  application/json
+baseUri: http://example.com
+
+protocols: [HTTP]
+
+/api:
+  displayName: API root
+  /first:
+    displayName: First endpoint
+    post:
+      displayName: First endpoint
+      description: Hello
+      body:
+        application/json:
+          examples:
+            First Request Example: {"description": "This is the first request example"}
+            Second Request Example: {"description": "This is the second request example"}
+      responses:
+          200:
+            description: A nice happy description
+            body:
+              application/json:
+                examples:
+                  First Example: {"description": "This is the first example"}
+                  Second Example: {"description": "This is the second example"}
+  /second:
+    displayName: Second endpoint
+    post:
+      body:
+        application/json:
+          example: {"description": "This is the third request example"}
+      responses:
+          200:
+            body:
+              application/json:
+                example: {"description": "This is the third example"}

--- a/tests/RamlWrapTest/tests/fixtures/raml/test_multiple_responses.raml
+++ b/tests/RamlWrapTest/tests/fixtures/raml/test_multiple_responses.raml
@@ -10,23 +10,35 @@ protocols: [HTTP]
 
 /api:
   displayName: API root
-  post:
-    body:
-      application/json:
-        schema: !include json/service_request.json
-        example: !include json/service_request_example.json
-    responses:
-        200:
-          description: A nice happy description
-          body:
-            application/json:
-              example: {"reason": "happyDays"}
-              schema: {"schema": "example"}
-        204:
-          description: No response body required
-        422:
-          body:
-            application/json:
-                example: {"reason": "invalidManatee"}
-        500:
-          description: A really unhappy server error.
+  /first:
+    displayName: First endpoint
+    post:
+      body:
+        application/json:
+          schema: !include json/service_request.json
+          example: !include json/service_request_example.json
+      responses:
+          200:
+            description: A nice happy description
+            body:
+              application/json:
+                example: {"reason": "happyDays"}
+                schema: {"schema": "example"}
+          204:
+            description: No response body required
+          422:
+            body:
+              application/json:
+                  example: {"reason": "invalidManatee"}
+          500:
+            description: A really unhappy server error.
+  /second:
+    displayName: Second endpoint
+    get:
+      body:
+        application/json:
+          schema: !include json/service_request.json
+          example: !include json/service_request_example.json
+      responses:
+          204:
+            description: No response body required

--- a/tests/RamlWrapTest/tests/test_raml_api_docs.py
+++ b/tests/RamlWrapTest/tests/test_raml_api_docs.py
@@ -11,16 +11,21 @@ from django.test import TestCase, Client
 
 class RamlApiDocsTestCase(TestCase):
 
-    def test_responses(self):
+    def test_first_endpoint_responses(self):
         """Test that the responses are returned as an array."""
         doc = RamlDoc()
         doc.raml_file = "RamlWrapTest/tests/fixtures/raml/test_multiple_responses.raml"
         context = doc._parse_endpoints(None)
 
-        self.assertEqual(len(context["endpoints"][0].methods[0].responses), 4)
+        # Find first endpoint (cannot guarantee order for Python 2.7 tests)
+        for endpoint in context["endpoints"]:
+            if endpoint.displayName == 'First endpoint':
+                first_endpoint_responses = endpoint.methods[0].responses
+
+        self.assertEqual(len(first_endpoint_responses), 4)
 
         # Python tests before 3.6 cannot guarantee order of responses so search based on code
-        for response in context["endpoints"][0].methods[0].responses:
+        for response in first_endpoint_responses:
             if response.status_code == 200:
                 self.assertEqual(response.description,
                                  'A nice happy description')
@@ -38,14 +43,34 @@ class RamlApiDocsTestCase(TestCase):
                 self.assertEqual(response.status_code, 500)
                 self.assertEqual(response.description, 'A really unhappy server error.')
 
-    def test_responses_backward_compatability(self):
-        """Test that 200 responses data is stored in legacy fields."""
+    def test_second_endpoint_responses(self):
+        """Test that the responses are returned as an array."""
         doc = RamlDoc()
         doc.raml_file = "RamlWrapTest/tests/fixtures/raml/test_multiple_responses.raml"
         context = doc._parse_endpoints(None)
 
-        self.assertEqual(context["endpoints"][0].methods[0].response_content_type, 'application/json')
-        self.assertEqual(context["endpoints"][0].methods[0].response_description, 'A nice happy description')
-        self.assertEqual(context["endpoints"][0].methods[0].response_example, {"reason": "happyDays"})
-        self.assertIsNone(context["endpoints"][0].methods[0].response_examples)
-        self.assertEqual(context["endpoints"][0].methods[0].response_schema, {"schema": "example"})
+        # Find first endpoint (cannot guarantee order for Python 2.7 tests)
+        for endpoint in context["endpoints"]:
+            if endpoint.displayName == 'Second endpoint':
+                second_endpoint_responses = endpoint.methods[0].responses
+
+        self.assertEqual(len(second_endpoint_responses), 1)
+        self.assertEqual(second_endpoint_responses[0].status_code, 204)
+        self.assertEqual(second_endpoint_responses[0].description, 'No response body required')
+
+    def test_responses_backward_compatability(self):
+        """Test that 200 responses data is stored in legacy fields for first endpoint."""
+        doc = RamlDoc()
+        doc.raml_file = "RamlWrapTest/tests/fixtures/raml/test_multiple_responses.raml"
+        context = doc._parse_endpoints(None)
+
+        # Find first endpoint (cannot guarantee order for Python 2.7 tests)
+        for endpoint in context["endpoints"]:
+            if endpoint.displayName == 'First endpoint':
+                first_endpoint_methods = endpoint.methods[0]
+
+        self.assertEqual(first_endpoint_methods.response_content_type, 'application/json')
+        self.assertEqual(first_endpoint_methods.response_description, 'A nice happy description')
+        self.assertEqual(first_endpoint_methods.response_example, {"reason": "happyDays"})
+        self.assertIsNone(first_endpoint_methods.response_examples)
+        self.assertEqual(first_endpoint_methods.response_schema, {"schema": "example"})

--- a/tests/RamlWrapTest/tests/test_raml_api_docs.py
+++ b/tests/RamlWrapTest/tests/test_raml_api_docs.py
@@ -11,14 +11,16 @@ from django.test import TestCase, Client
 
 class RamlApiDocsTestCase(TestCase):
 
-    def test_first_endpoint_responses(self):
-        """Test that the responses are returned as an array."""
+    def setUp(self):
         doc = RamlDoc()
         doc.raml_file = "RamlWrapTest/tests/fixtures/raml/test_multiple_responses.raml"
-        context = doc._parse_endpoints(None)
+        self.context = doc._parse_endpoints(None)
 
+    def test_first_endpoint_responses(self):
+        """Test that the responses are returned as an array."""
         # Find first endpoint (cannot guarantee order for Python 2.7 tests)
-        for endpoint in context["endpoints"]:
+        first_endpoint_responses = None
+        for endpoint in self.context["endpoints"]:
             if endpoint.displayName == 'First endpoint':
                 first_endpoint_responses = endpoint.methods[0].responses
 
@@ -38,19 +40,16 @@ class RamlApiDocsTestCase(TestCase):
                 self.assertEqual(response.status_code, 422)
                 self.assertIsNone(response.description)
                 self.assertEqual(len(response.examples), 1)
-                self.assertEqual(response.examples[0], {"reason": "invalidManatee"})
+                self.assertEqual(response.examples[0].body, {"reason": "invalidManatee"})
             elif response.status_code == 500:
                 self.assertEqual(response.status_code, 500)
                 self.assertEqual(response.description, 'A really unhappy server error.')
 
     def test_second_endpoint_responses(self):
         """Test that the responses are returned as an array."""
-        doc = RamlDoc()
-        doc.raml_file = "RamlWrapTest/tests/fixtures/raml/test_multiple_responses.raml"
-        context = doc._parse_endpoints(None)
-
         # Find first endpoint (cannot guarantee order for Python 2.7 tests)
-        for endpoint in context["endpoints"]:
+        second_endpoint_responses = None
+        for endpoint in self.context["endpoints"]:
             if endpoint.displayName == 'Second endpoint':
                 second_endpoint_responses = endpoint.methods[0].responses
 
@@ -60,12 +59,9 @@ class RamlApiDocsTestCase(TestCase):
 
     def test_responses_backward_compatability(self):
         """Test that 200 responses data is stored in legacy fields for first endpoint."""
-        doc = RamlDoc()
-        doc.raml_file = "RamlWrapTest/tests/fixtures/raml/test_multiple_responses.raml"
-        context = doc._parse_endpoints(None)
-
         # Find first endpoint (cannot guarantee order for Python 2.7 tests)
-        for endpoint in context["endpoints"]:
+        first_endpoint_methods = None
+        for endpoint in self.context["endpoints"]:
             if endpoint.displayName == 'First endpoint':
                 first_endpoint_methods = endpoint.methods[0]
 
@@ -74,3 +70,94 @@ class RamlApiDocsTestCase(TestCase):
         self.assertEqual(first_endpoint_methods.response_example, {"reason": "happyDays"})
         self.assertIsNone(first_endpoint_methods.response_examples)
         self.assertEqual(first_endpoint_methods.response_schema, {"schema": "example"})
+
+
+class RamlApiDocsExamplesTestCase(TestCase):
+
+    def setUp(self):
+        doc = RamlDoc()
+        doc.raml_file = "RamlWrapTest/tests/fixtures/raml/test_multiple_examples.raml"
+        self.context = doc._parse_endpoints(None)
+
+    def test_multiple_response_examples(self):
+        """Test that the responses are returned as an array."""
+        # Find first endpoint examples (cannot guarantee order for Python 2.7 tests)
+        first_endpoint_examples = None
+        for endpoint in self.context["endpoints"]:
+            if endpoint.displayName == 'First endpoint':
+                first_endpoint_examples = endpoint.methods[0].responses[0].examples
+
+        self.assertEqual(len(first_endpoint_examples), 2)
+        for example in first_endpoint_examples:
+            if example.title == 'First Example':
+                self.assertEqual(example.body, {"description": "This is the first example"})
+            elif example.title == 'Second Example':
+                self.assertEqual(example.body, {"description": "This is the second example"})
+            else:
+                raise ValueError('Invalid title found ' + example.title)
+
+    def test_single_response_examples(self):
+        """Test that the responses are returned as an array."""
+        # Find first endpoint examples (cannot guarantee order for Python 2.7 tests)
+        second_endpoint_examples = None
+        for endpoint in self.context["endpoints"]:
+            if endpoint.displayName == 'Second endpoint':
+                second_endpoint_examples = endpoint.methods[0].responses[0].examples
+
+        self.assertEqual(len(second_endpoint_examples), 1)
+        self.assertIsNone(second_endpoint_examples[0].title)
+        self.assertEqual(second_endpoint_examples[0].body, {"description": "This is the third example"})
+
+    def test_multiple_request_examples(self):
+        """Test that the responses are returned as an array."""
+        # Find first endpoint request examples (cannot guarantee order for Python 2.7 tests)
+        first_endpoint_request_examples = None
+        for endpoint in self.context["endpoints"]:
+            if endpoint.displayName == 'First endpoint':
+                first_endpoint_request_examples = endpoint.methods[0].examples
+
+        self.assertEqual(len(first_endpoint_request_examples), 2)
+        for example in first_endpoint_request_examples:
+            if example.title == 'First Request Example':
+                self.assertEqual(example.body, {"description": "This is the first request example"})
+            elif example.title == 'Second Request Example':
+                self.assertEqual(example.body, {"description": "This is the second request example"})
+            else:
+                raise ValueError('Invalid title found ' + example.title)
+
+    def test_single_request_example(self):
+        """Test that the responses are returned as an array."""
+        # Find second endpoint request examples (cannot guarantee order for Python 2.7 tests)
+        second_endpoint_request_examples = None
+        for endpoint in self.context["endpoints"]:
+            if endpoint.displayName == 'Second endpoint':
+                second_endpoint_request_examples = endpoint.methods[0].examples
+
+        self.assertEqual(len(second_endpoint_request_examples), 1)
+        self.assertIsNone(second_endpoint_request_examples[0].title)
+        self.assertEqual(second_endpoint_request_examples[0].body, {"description": "This is the third request example"})
+
+    def test_multiple_request_examples_backward_compatability(self):
+        """Test that request_examples is set correctly"""
+        # Find first endpoint request examples (cannot guarantee order for Python 2.7 tests)
+        first_endpoint_method = None
+        for endpoint in self.context["endpoints"]:
+            if endpoint.displayName == 'First endpoint':
+                first_endpoint_method = endpoint.methods[0]
+
+        expected_examples = {
+            'First Request Example': {"description": "This is the first request example"},
+            'Second Request Example': {"description": "This is the second request example"}
+        }
+
+        self.assertEqual(first_endpoint_method.request_examples, expected_examples)
+
+    def test_single_request_example_backward_compatability(self):
+        """Test that request_example is set correctly"""
+        # Find second endpoint request method (cannot guarantee order for Python 2.7 tests)
+        second_endpoint_method = None
+        for endpoint in self.context["endpoints"]:
+            if endpoint.displayName == 'Second endpoint':
+                second_endpoint_method = endpoint.methods[0]
+
+        self.assertEqual(second_endpoint_method.request_example, {"description": "This is the third request example"})


### PR DESCRIPTION
Two minor bug fixes and improvements:
1. Responses array now created in instance init - not statically on class
2. New Examples class used for RAML `examples` and `example` in responses array and method request examples

