### PR TITLE
Support multiple content types in request body

### DIFF
--- a/ramlwrap/utils/raml.py
+++ b/ramlwrap/utils/raml.py
@@ -108,10 +108,20 @@ def _parse_child(resource, patterns, to_look_at, function_map, defaults):
                 if 'body' in act:
                     # if body, look for content type : if not there maybe not valid raml?
                     # FIXME: this may be a bug requring a try/catch - need more real world example ramls
-                    a.requ_content_type = next(iter(act['body']))
-                    # Also look for a schema here
-                    if "schema" in act['body'][a.requ_content_type]:
-                        a.schema = act['body'][a.requ_content_type]['schema']
+                    request_options = {}
+                    request_content_type_options = []
+                    for i in act["body"].items():
+                        if "schema" in i:
+                            request_options[i[0]] = {"schema": i[1]["schema"]}
+
+                        else:
+                            request_options[i[0]] = {"schema": None}
+
+                        request_content_type_options.append(i[0])
+
+                    a.request_options = request_options
+                    a.request_content_type_options = request_content_type_options
+
 
                 # These horrendous if blocks are to get around none type errors when the tree
                 # is not fully built out.
@@ -119,7 +129,7 @@ def _parse_child(resource, patterns, to_look_at, function_map, defaults):
                 if 'responses' in act and act['responses']:
                     for status_code in act['responses']:
                         # this is a response that we care about:
-                        
+
                         if status_code == 200:
                             two_hundred = act['responses'][200]
                             for resp_attr in two_hundred:
@@ -135,7 +145,7 @@ def _parse_child(resource, patterns, to_look_at, function_map, defaults):
                                             examples = two_hundred['body'][a.resp_content_type]['examples'].values()
                                             value_iterator = iter(examples)
                                             a.example = next(value_iterator)
-                                        
+
                 if "queryParameters" in act and act["queryParameters"]:
                     # FIXME: does this help in the query parameterising?
                     # For filling out a.queryparameterchecks

--- a/ramlwrap/utils/raml.py
+++ b/ramlwrap/utils/raml.py
@@ -113,11 +113,11 @@ def _parse_child(resource, patterns, to_look_at, function_map, defaults):
                     # For each body defined in the raml, store the content type and schema if present
                     for i in act["body"].items():
                         request_content_type_options.append(i[0])
-                        if "schema" in i:
-                            request_options[i[0]] = {"schema": i[1]["schema"]}
+                        request_options[i[0]] = {"schema": None}
 
-                        else:
-                            request_options[i[0]] = {"schema": None}
+                        if len(i) > 1 and i[1]:
+                            if "schema" in i[1]:
+                                request_options[i[0]] = {"schema": i[1]["schema"]}
 
                     a.request_options = request_options
                     a.request_content_type_options = request_content_type_options
@@ -129,7 +129,6 @@ def _parse_child(resource, patterns, to_look_at, function_map, defaults):
                 if 'responses' in act and act['responses']:
                     for status_code in act['responses']:
                         # this is a response that we care about:
-
                         if status_code == 200:
                             two_hundred = act['responses'][200]
                             for resp_attr in two_hundred:

--- a/ramlwrap/utils/raml.py
+++ b/ramlwrap/utils/raml.py
@@ -106,18 +106,18 @@ def _parse_child(resource, patterns, to_look_at, function_map, defaults):
                         logger.error("Url: [%s] appears to have a dynamic component but there is no function map for it. You must define the regex in the function map to prevent errors" % path)
 
                 if 'body' in act:
-                    # if body, look for content type : if not there maybe not valid raml?
+                    # if body, look for content type
                     # FIXME: this may be a bug requring a try/catch - need more real world example ramls
                     request_options = {}
                     request_content_type_options = []
+                    # For each body defined in the raml, store the content type and schema if present
                     for i in act["body"].items():
+                        request_content_type_options.append(i[0])
                         if "schema" in i:
                             request_options[i[0]] = {"schema": i[1]["schema"]}
 
                         else:
                             request_options[i[0]] = {"schema": None}
-
-                        request_content_type_options.append(i[0])
 
                     a.request_options = request_options
                     a.request_content_type_options = request_content_type_options

--- a/ramlwrap/utils/validation.py
+++ b/ramlwrap/utils/validation.py
@@ -147,7 +147,7 @@ def _generate_example(action):
     This is used by both GET and POST when returning an example 
     """
     # The original method of generating straight from the example is bad
-    # because v2 parser now has an object, which also allows us to do the 
+    # because v2 parser now has an object, which also allows us to do the
     # headers correctly
 
     ret_data = action.example
@@ -214,18 +214,22 @@ def _validate_body(request, action):
 
     content_type_matched = False
 
+    # Set the actual content_type we are using in this request
+    action.requ_content_type = request_content_type
+
     # Check the schema had content-types defined
     if hasattr(action, 'request_content_type_options'):
         for x in action.request_content_type_options:
             # Check if the incoming content-type matches the allowed type in the schema and is JSON type
             if x == request_content_type == str(ContentType.JSON):
                 content_type_matched = True
+
                 # If the expected request body is JSON, we need to load it.
-                if action.schema:
+                if action.request_options[request_content_type]["schema"]:
                     # If there is any schema, we'll validate it.
                     try:
                         data = json.loads(request.body.decode('utf-8'))
-                        validate(data, action.schema)
+                        validate(data, action.request_options[request_content_type]["schema"])
                     except Exception as e:
                         # Check the value is in settings, and that it is not None
                         if hasattr(settings,

--- a/ramlwrap/utils/validation.py
+++ b/ramlwrap/utils/validation.py
@@ -149,7 +149,7 @@ def _generate_example(action):
     # The original method of generating straight from the example is bad
     # because v2 parser now has an object, which also allows us to do the 
     # headers correctly
-    
+
     ret_data = action.example
     # FIXME: not sure about this content thing
     if action.resp_content_type == "application/json":
@@ -205,31 +205,46 @@ def _validate_api(request, action, dynamic_values=None):
 def _validate_body(request, action):
     error_response = None
 
-    if action.requ_content_type == ContentType.JSON:
-        # If the expected request body is JSON, we need to load it.
-        if action.schema:
-            # If there is any schema, we'll validate it.
-            try:
-                data = json.loads(request.body.decode('utf-8'))
-                validate(data, action.schema)
-            except Exception as e:
-                # Check the value is in settings, and that it is not None
-                if hasattr(settings,
-                           'RAMLWRAP_VALIDATION_ERROR_HANDLER') and settings.RAMLWRAP_VALIDATION_ERROR_HANDLER:
-                    error_response = _call_custom_handler(e, request, action)
-                else:
-                    error_response = _validation_error_handler(e)
-        else:
-            # Otherwise just load it (no validation as no schema).
-            data = json.loads(request.body.decode('utf-8'))
+    # Grab the content-type coming in from the request
+    if "headers" in request.META:
+        request_content_type = request.META["headers"]["content-type"]
+
     else:
-        # The content isn't JSON
-        try:
-            # Decode it as it is
+        request_content_type = request.META["CONTENT_TYPE"]
+
+    for x in action.request_content_type_options:
+        content_type_matched = False
+
+        # Check if the incoming content-type matches the allowed type in the schema and is JSON type
+        if x == request_content_type == str(ContentType.JSON):
+            content_type_matched = True
+            # If the expected request body is JSON, we need to load it.
+            if action.schema:
+                # If there is any schema, we'll validate it.
+                try:
+                    data = json.loads(request.body.decode('utf-8'))
+                    validate(data, action.schema)
+                except Exception as e:
+                    # Check the value is in settings, and that it is not None
+                    if hasattr(settings,
+                               'RAMLWRAP_VALIDATION_ERROR_HANDLER') and settings.RAMLWRAP_VALIDATION_ERROR_HANDLER:
+                        error_response = _call_custom_handler(e, request, action)
+                    else:
+                        error_response = _validation_error_handler(e)
+            else:
+                # Otherwise just load it (no validation as no schema).
+                data = json.loads(request.body.decode('utf-8'))
+            break
+
+        # Incoming content type wasn't json but it does match one of the options in the raml
+        elif x == request_content_type:
+            content_type_matched = True
+            # The content isn't JSON but it matches one of the schema options, so just decode it as is
             data = request.body.decode('utf-8')
-        except UnicodeDecodeError as e:
-            # Just send the body if it cannot be decoded
-            data = request.body
+            break
+
+    if not content_type_matched:
+        error_response = _validation_error_handler(ValidationError("Invalid Content Type for this request: {}".format(request_content_type), validator="invalid"))
 
     if not error_response:
         request.validated_data = data

--- a/ramlwrap/utils/validation.py
+++ b/ramlwrap/utils/validation.py
@@ -241,14 +241,21 @@ def _validate_body(request, action):
             # Incoming content type wasn't json but it does match one of the options in the raml so just decode it as is
             elif x == request_content_type:
                 content_type_matched = True
-                data = request.body.decode('utf-8')
+                try:
+                    data = request.body.decode('utf-8')
+                except UnicodeDecodeError:
+                    # Just send the body if it cannot be decoded
+                    data = request.body
                 break
 
     else:
         # There were no content type options in the schema so just load the data
         content_type_matched = True
-        data = request.body.decode('utf-8')
-
+        try:
+            data = request.body.decode('utf-8')
+        except UnicodeDecodeError:
+            # Just send the body if it cannot be decoded
+            data = request.body
 
     if not content_type_matched:
         error_response = _validation_error_handler(ValidationError("Invalid Content Type for this request: {}".format(request_content_type), validator="invalid"))

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
 
-    version='2.3.4',
+    version='2.3.5',
 
     description='Raml API mapping toolkit for Django',
     long_description=long_description,

--- a/tests/RamlWrapTest/tests/fixtures/raml/test.raml
+++ b/tests/RamlWrapTest/tests/fixtures/raml/test.raml
@@ -130,3 +130,17 @@ protocols: [HTTP]
           body:
             application/json:
                 example: {"exampleData": "You just made a DELETE request"}
+  /multi_content_type:
+    displayName: API for testing multiple content types
+    description: Example POST API
+    post:
+      body:
+        application/json:
+          schema: !include json/service_request.json
+          example: !include json/service_request_example.json
+        application/x-www-form-urlencoded:
+      responses:
+        200:
+          body:
+            application/json:
+                 example: {"exampleData": "You just made a POST request"}

--- a/tests/RamlWrapTest/tests/fixtures/raml/test.raml
+++ b/tests/RamlWrapTest/tests/fixtures/raml/test.raml
@@ -136,11 +136,18 @@ protocols: [HTTP]
     post:
       body:
         application/json:
-          schema: !include json/service_request.json
-          example: !include json/service_request_example.json
         application/x-www-form-urlencoded:
       responses:
         200:
           body:
             application/json:
                  example: {"exampleData": "You just made a POST request"}
+  /no_content_type:
+      displayName: API for testing with no defined content types
+      description: Example POST API
+      post:
+        responses:
+          200:
+            body:
+              application/json:
+                   example: {"exampleData": "You just made a POST request"}

--- a/tests/RamlWrapTest/tests/test_ramlwrap.py
+++ b/tests/RamlWrapTest/tests/test_ramlwrap.py
@@ -100,6 +100,8 @@ class RamlWrapTestCase(TestCase):
             "api/5": {"PUT": {}},
             "api/patch-api": {"PATCH": {}},
             "api/delete-api": {"DELETE": {}},
+            "api/multi_content_type": {"POST": {}},
+            "api/no_content_type": {"POST": {}},
         }
 
         for pattern in patterns:

--- a/tests/RamlWrapTest/tests/test_validation.py
+++ b/tests/RamlWrapTest/tests/test_validation.py
@@ -112,6 +112,34 @@ class ValidationTestCase(TestCase):
             with self.assertRaises(ValidationError):
                 self.client.get("/api/3?%s" % params)
 
+    def test_post_with_valid_content_types(self):
+        # List of valid content types, as defined in the raml file
+        valid_content_types = [
+            "application/json",
+            "application/x-www-form-urlencoded"
+        ]
+
+        request_data = {"data":"value"}
+
+        for content_type in valid_content_types:
+            headers = {"content-type": content_type}
+            response = self.client.post('/api/multi_content_type', json.dumps(request_data), headers=headers)
+            self.assertEquals(response.status_code, 200)
+
+    def test_post_with_invalid_content_types(self):
+        # List of valid content types, but which aren't defined in the raml file
+        valid_content_types = [
+            "text/plain",
+            "application/xml"
+        ]
+
+        request_data = {"data":"value"}
+
+        for content_type in valid_content_types:
+            headers = {"content-type": content_type}
+            response = self.client.post('/api/multi_content_type', json.dumps(request_data), headers=headers)
+            self.assertEquals(response.status_code, 500)
+
     def test_validation_handler(self):
         """
         Test that given a custom validation handler path, it is called.

--- a/tests/RamlWrapTest/urls.py
+++ b/tests/RamlWrapTest/urls.py
@@ -43,7 +43,9 @@ function_map = {
     'notdynamic_old': regular_api,
 
     # url with multiple content-types
-    'multi_content_type': {'function': regular_api}
+    'api/multi_content_type': {'function': regular_api},
+    'api/no_content_type': {'function': regular_api},
+
 }
 
 # Load in test raml file

--- a/tests/RamlWrapTest/urls.py
+++ b/tests/RamlWrapTest/urls.py
@@ -40,7 +40,10 @@ function_map = {
     'dynamicapi/{dynamic_id}/{dynamic_id_2}': {'regex': {'dynamic_id': '(?P<dynamic_id>[a-zA-Z]+)', 'dynamic_id_2': '(?P<dynamic_id_2>[0-9]+)'}},
 
     'notdynamic': {'function': regular_api},
-    'notdynamic_old': regular_api
+    'notdynamic_old': regular_api,
+
+    # url with multiple content-types
+    'multi_content_type': {'function': regular_api}
 }
 
 # Load in test raml file


### PR DESCRIPTION
* Update to allow multiple content-types in the request body of schema
* validation to check incoming request content type matches one defined in the schema (will only validate if the schema defines a content_type)
* unit tests