### PR TITLE
More flexible content type

### DIFF
--- a/ramlwrap/utils/exceptions.py
+++ b/ramlwrap/utils/exceptions.py
@@ -21,30 +21,6 @@ class FatalException(Exception):
     Custom CBP Exception, allows custom status_code definition.
     """
 
-    status_code = None  # Will default to 400 in constructor
-    message = ""  # Error message is set in constructor
-    errors = None
-    public_message = "Sorry, there has been an error. Please check the server logs. (Middleware)"
-
-    def __init__(self, message, status_code=400, errors=None, public_message=None):
-
-        self.status_code = status_code
-
-        if public_message:
-            self.public_message = public_message
-
-        self.errors = errors
-        self.message = message
-
-    def __str__(self):
-        return repr(self.message)
-
-
-class FatalException(Exception):
-    """
-    Custom CBP Exception, allows custom status_code definition.
-    """
-    
     default_code = 500
 
     status_code = None  # Will default to 400 in constructor
@@ -66,3 +42,16 @@ class FatalException(Exception):
 
     def __str__(self):
         return repr(self.message)
+
+
+class UnsupportedMediaTypeException(Exception):
+    """
+    Exception to be raised if no content type is passed in
+    """
+
+    status_code = 415  # Will default to 400 in constructor
+    message = ""  # Error message is set in constructor
+
+    def __init__(self, message, status_code=415):
+        self.status_code = status_code
+        self.message = message

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
 
-    version='2.3.6',
+    version='2.3.7',
 
     description='Raml API mapping toolkit for Django',
     long_description=long_description,
@@ -73,7 +73,7 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        "Django>=1.11.0",
+        "Django>=2.0",
         "jsonschema>=2.6.0",
         "pyyaml>=3.12"
     ]

--- a/tests/RamlWrapTest/tests/test_validation.py
+++ b/tests/RamlWrapTest/tests/test_validation.py
@@ -13,11 +13,7 @@ from django.test import TestCase, Client
 from django.test.client import RequestFactory
 
 from jsonschema.exceptions import ValidationError
-import sys
-import logging
 
-logger = logging.getLogger()
-logger.level = logging.DEBUG
 
 def _mock_post_target(request, dynamic_value=None):
     """Return true if the validated data is correct."""
@@ -50,8 +46,6 @@ class ValidationTestCase(TestCase):
 
     def setUp(self):
         self.client = Client()
-        stream_handler = logging.StreamHandler(sys.stdout)
-        logger.addHandler(stream_handler)
 
     def test_raml_schema_validation(self):
         """Test that when schema is present, it is used to

--- a/tests/RamlWrapTest/tests/test_validation.py
+++ b/tests/RamlWrapTest/tests/test_validation.py
@@ -13,7 +13,11 @@ from django.test import TestCase, Client
 from django.test.client import RequestFactory
 
 from jsonschema.exceptions import ValidationError
+import sys
+import logging
 
+logger = logging.getLogger()
+logger.level = logging.DEBUG
 
 def _mock_post_target(request, dynamic_value=None):
     """Return true if the validated data is correct."""
@@ -46,6 +50,8 @@ class ValidationTestCase(TestCase):
 
     def setUp(self):
         self.client = Client()
+        stream_handler = logging.StreamHandler(sys.stdout)
+        logger.addHandler(stream_handler)
 
     def test_raml_schema_validation(self):
         """Test that when schema is present, it is used to
@@ -119,7 +125,8 @@ class ValidationTestCase(TestCase):
 
         valid_content_types = [
             "application/json",
-            "application/x-www-form-urlencoded"
+            "application/x-www-form-urlencoded",
+            "application/json; charset=utf-8"
         ]
 
         for content_type in valid_content_types:
@@ -140,7 +147,7 @@ class ValidationTestCase(TestCase):
             response = self.client.post('/api/multi_content_type', data="{}", content_type=content_type)
             self.assertEquals(response.status_code, 422)
 
-    def test_post_with_no_content_types(self):
+    def test_post_with_no_content_types_in_schema(self):
         """
         Check that making a request with a content type
         but to a url which has no defined content types in the schema, passes
@@ -157,6 +164,14 @@ class ValidationTestCase(TestCase):
         for content_type in content_types:
             response = self.client.post('/api/no_content_type', data="{}", content_type=content_type)
             self.assertEquals(response.status_code, 200)
+
+    def test_post_with_no_content_type_in_request(self):
+        """
+        Check that an empty content-type in request results in 415 error
+        """
+
+        response = self.client.post('/api/multi_content_type', data="{}", content_type="")
+        self.assertEquals(response.status_code, 415)
 
     def test_validation_handler(self):
         """

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,6 @@ deps =
     django2.2: Django>=2.2,<3.0
     django2.1: Django>=2.1,<2.2
     django2.0: Django>=2.0,<2.1
-    django1.11: Django>=1.11,<2.0
     mock==3.0.5
     jsonschema==3.2.0
     pyyaml==5.3


### PR DESCRIPTION
* Updating content-type validation to get the first value (in case of optional extras in the content-type header) and using that to validate against raml file
* If no content-type is found in the request, return 415 error
* unit tests to support the above
* removal of django 1.11 support
* also deleted duplicate fatal exception declaration